### PR TITLE
FIWARE Lab performance fix

### DIFF
--- a/keystone/auth/controllers.py
+++ b/keystone/auth/controllers.py
@@ -522,6 +522,7 @@ class Auth(controller.V3Controller):
     def validate_token(self, context):
         token_id = context.get('subject_token_id')
         include_catalog = 'nocatalog' not in context['query_string']
+        include_catalog = False
         token_data = self.token_provider_api.validate_v3_token(
             token_id)
         if not include_catalog and 'catalog' in token_data['token']:

--- a/keystone/token/providers/common.py
+++ b/keystone/token/providers/common.py
@@ -604,5 +604,6 @@ class BaseProvider(provider.Provider):
                 bind=token_ref.get('bind'),
                 expires=token_ref['expires'],
                 issued_at=issued_at,
-                audit_info=audit)
+                audit_info=audit,
+                include_catalog=False)
         return token_data


### PR DESCRIPTION
Every token validated in v3 protocol was quering the whole catalog and delivering it. This meant over 2000 queries to database, 100Kb of unused data just on every token validation. This token validation lasted over 5 seconds in the best case. The performance was becoming really poor as the infrastrucutre grew. So this changes prevents the catalog to be queried and deliveried in token validation (/v3/auth/token).
